### PR TITLE
Add docker image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,33 @@
+FROM node:8.11.0
+
+RUN apt-get update
+
+# Installing the packages needed to run Nightmare
+RUN apt-get install -y \
+  xvfb \
+  x11-xkb-utils \
+  xfonts-100dpi \
+  xfonts-75dpi \
+  xfonts-scalable \
+  xfonts-cyrillic \
+  x11-apps \
+  clang \
+  libdbus-1-dev \
+  libgtk2.0-dev \
+  libnotify-dev \
+  libgnome-keyring-dev \
+  libgconf2-dev \
+  libasound2-dev \
+  libcap-dev \
+  libcups2-dev \
+  libxtst-dev \
+  libxss1 \
+  libnss3-dev \
+  gcc-multilib \
+  g++-multilib
+RUN apt-get autoremove
+RUN npm install --global nightmare xvfb pageres-cli --unsafe-perm
+USER node
+WORKDIR /tmp
+ENTRYPOINT ["pageres"]
+CMD ["--help"]

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,6 @@
+build:
+	docker build -t nutellinoit/pageres:1.0 .
+	docker tag nutellinoit/pageres:1.0 nutellinoit/pageres:latest
+push:
+	docker push nutellinoit/pageres:1.0
+	docker push nutellinoit/pageres:latest

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,11 @@
+# Docker image
+
+Build tldr container with:
+
+```bash
+make build
+```
+
+Add alias on `~/.bashrc` or `~/.zshrc`: `alias pageres='docker run --rm -it -v ${PWD}:/tmp/ nutellinoit/pageres'`
+
+Use `pageres` command


### PR DESCRIPTION
Added the ability to use pageres by running a container using alias.

Add alias on `~/.bashrc` or `~/.zshrc`: `alias pageres='docker run --rm -it -v ${PWD}:/tmp/ nutellinoit/pageres'`
